### PR TITLE
Rescue invalid errors and pass up the relevant data to fix

### DIFF
--- a/lib/client_auth/models/error_serializer.rb
+++ b/lib/client_auth/models/error_serializer.rb
@@ -10,6 +10,8 @@ module ClientAuth
       attrs = JSON.parse(data)['errors'].first
       klass = attrs['title'].constantize
       klass.new(attrs['status'], attrs['detail'])
+    rescue StandardError
+      ::ClientAuth::Errors::InternalServerError.new(data)
     end
   end
 end


### PR DESCRIPTION
We were receiving non-regular errors from Encompass, but this didn't know how to handle them. The result is we end up with useless errors because we lose the data that caused the error!

This PR makes the error handler pass up the data itself if it can't parse it.