### PR TITLE
Update error handling once again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
 
       - run:
           name: run tests
-          command: rspec spec/
+          command: bundle exe rspec spec/
 
       - store_test_results:
           path: /tmp/test-results

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,38 @@
 PATH
   remote: .
   specs:
-    client-auth (1.0.6)
+    client-auth (1.0.7)
       activesupport
       rest-client
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.2)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     ast (2.3.0)
     coderay (1.1.1)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    domain_name (0.5.20170223)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     hashdiff (0.3.2)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.8.1)
+    i18n (1.1.1)
+      concurrent-ruby (~> 1.0)
     method_source (0.8.2)
-    mime-types (3.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
-    minitest (5.10.1)
+    mime-types-data (3.2018.0812)
+    minitest (5.11.3)
     netrc (0.11.0)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -43,7 +44,7 @@ GEM
     public_suffix (2.0.5)
     rainbow (2.2.1)
     rake (10.5.0)
-    rest-client (2.0.1)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -75,11 +76,11 @@ GEM
     safe_yaml (1.0.4)
     slop (3.6.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.2)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.5)
     unicode-display_width (1.1.3)
     webmock (2.3.2)
       addressable (>= 2.3.6)
@@ -100,4 +101,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.5
+   1.16.0

--- a/client-auth.gemspec
+++ b/client-auth.gemspec
@@ -6,8 +6,8 @@ require 'client_auth/version'
 Gem::Specification.new do |spec|
   spec.name          = 'client-auth'
   spec.version       = ClientAuth::VERSION
-  spec.authors       = ['Yuriy Lavryk']
-  spec.email         = ['yuriy@getmatic.com']
+  spec.authors       = ['Yuriy Lavryk', 'Xavier Hocquet']
+  spec.email         = ['yuriy@getmatic.com', 'xavier@himaxwell.com']
 
   spec.summary       = 'Authentication client'
   spec.description   = 'Authentication for matic clients'

--- a/lib/client_auth/models/error_serializer.rb
+++ b/lib/client_auth/models/error_serializer.rb
@@ -7,7 +7,11 @@ module ClientAuth
     end
 
     def self.deserialize(data)
-      attrs = JSON.parse(data)['errors'].first
+      parsed_errors = JSON.parse(data)['errors']
+
+      return ::ClientAuth::Errors::InternalServerError.new(data) if parsed_errors.nil?
+
+      attrs = parsed_errors.first
       klass = attrs['title'].constantize
       klass.new(attrs['status'], attrs['detail'])
     rescue StandardError

--- a/lib/client_auth/version.rb
+++ b/lib/client_auth/version.rb
@@ -1,4 +1,4 @@
 # File is auto-generated.
 module ClientAuth
-  VERSION = '1.0.6'.freeze
+  VERSION = '1.0.7'.freeze
 end


### PR DESCRIPTION
 - For some reason, the `rescue StandardError` is not picking up errors that are getting swallowed 
 - Now, explicitly check the `nil` failure and try to pass on the error 